### PR TITLE
fix: playground build error

### DIFF
--- a/projects/playground/src/app/app.component.ts
+++ b/projects/playground/src/app/app.component.ts
@@ -29,7 +29,7 @@ export class AppComponent implements OnInit {
   }
 
   getToken() {
-    this.authService.getAccessToken().subscribe(token => console.log(token));
+    this.authService.accessToken$.subscribe(token => console.log(token));
   }
 
   handleCallback() {


### PR DESCRIPTION
When running the playground it failed to run because was unable to subscribe to a string. 

This resolves the issue.